### PR TITLE
Updated to match newer nMigen API

### DIFF
--- a/hello_memory/rom.py
+++ b/hello_memory/rom.py
@@ -1,6 +1,6 @@
 from nmigen import *
 from math import ceil, log2
-from nmigen.back.pysim import *
+from nmigen.sim import *
 from nmigen_soc.memory import *
 from nmigen_soc.wishbone import *
 
@@ -66,7 +66,8 @@ if __name__ == "__main__":
                0x0C0FFEE0, 0xDEC0FFEE,
                0xFEEBEEDE ] )
   # Run the simulation.
-  with Simulator( dut, vcd_file = open( 'rom.vcd', 'w' ) ) as sim:
+  sim = Simulator(dut)
+  with sim.write_vcd('rom.vcd'):
     def proc():
       # Test reads.
       yield from rom_read_ut( dut, 0, 0x01234567 )

--- a/hello_memory/top.py
+++ b/hello_memory/top.py
@@ -1,5 +1,5 @@
 from nmigen import *
-from nmigen.back.pysim import *
+from nmigen.sim import *
 from nmigen_boards.upduino_v2 import *
 from nmigen_soc.wishbone import *
 from nmigen_soc.memory import *
@@ -132,7 +132,8 @@ if __name__ == "__main__":
       BLU_ON, DELAY( 5 ), GRN_ON, DELAY( 5 ), BLU_OFF, RED_ON,
       DELAY( 10 ), RED_OFF, DELAY( 5 ), GRN_OFF, DELAY( 5 ), RETURN
     ] ) )
-    with Simulator( dut, vcd_file = open( 'test.vcd', 'w' ) ) as sim:
+    sim = Simulator(dut)
+    with sim.write_vcd('test.vcd'):
       # Simulate running for 200 clock cycles.
       def proc():
         for i in range( 200 ):

--- a/hello_nmigen/test.py
+++ b/hello_nmigen/test.py
@@ -13,11 +13,12 @@ class TestModule( Elaboratable ):
       m.d.sync += self.count.eq( 0 )
     return m
 
-from nmigen.back.pysim import *
+from nmigen.sim import *
 
 if __name__ == "__main__":
   dut = TestModule()
-  with Simulator( dut, vcd_file = open( 'test.vcd', 'w' ) ) as sim:
+  sim = Simulator(dut)
+  with sim.write_vcd('test.vcd'):
     def proc():
       # Run for 50 clock cycles, and check that the 'count' signal
       # equals the number of elapsed cycles. This should start

--- a/hello_spi/top.py
+++ b/hello_spi/top.py
@@ -1,5 +1,5 @@
 from nmigen import *
-from nmigen.back.pysim import *
+from nmigen.sim import *
 from nmigen_boards.upduino_v2 import *
 from nmigen_soc.wishbone import *
 from nmigen_soc.memory import *
@@ -145,8 +145,9 @@ if __name__ == "__main__":
       BLU_ON, DELAY( 5 ), GRN_ON, DELAY( 5 ), BLU_OFF, RED_ON,
       DELAY( 10 ), RED_OFF, DELAY( 5 ), GRN_OFF, DELAY( 5 ), RETURN
     ] ) )
-    with Simulator( dut, vcd_file = open( 'test.vcd', 'w' ) ) as sim:
-      # Simulate running for 200 clock cycles.
+    sim = Simulator(dut)
+    with sim.write_vcd('test.vcd'):
+      # Simulate running for 5000 clock cycles.
       def proc():
         for i in range( 5000 ):
           yield Tick()


### PR DESCRIPTION
Several changes to match changes in nMigen over the last few months:

(a) Simulator class has moved from nmigen.back.pysim to nmigen.sim

(b) API for writing to VCD file has changed. Was "with
Simulator(vcd_file=...):". Is now "with sim.write_vcd(...):".

(c) Match change from MISO and MOSI to CIPO and COPI.

Tested with nMigen at 69ed4918b8b9fc8617064bbfacb92feb720006f2